### PR TITLE
Implement NodeSigner trait for LND Node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitcoin = "0.29.2"
 futures = "0.3.26"
+lightning = "0.0.114"
 tokio = { version = "1.25.0", features = ["rt", "rt-multi-thread"] }
-tonic_lnd = "0.5.0"
+tonic_lnd = { git = "https://github.com/Kixunil/tonic_lnd", rev = "c30b614" } 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,14 @@
+use bitcoin::bech32::u5;
+use bitcoin::secp256k1::ecdh::SharedSecret;
+use bitcoin::secp256k1::ecdsa::{RecoverableSignature, Signature};
+use bitcoin::secp256k1::{self, PublicKey, Scalar, Secp256k1};
 use futures::executor::block_on;
+use lightning::chain::keysinterface::{KeyMaterial, NodeSigner, Recipient};
+use lightning::ln::msgs::UnsignedGossipMessage;
+use std::cell::RefCell;
 use std::error::Error;
 use std::fmt;
+use std::str::FromStr;
 use tonic_lnd::{Client, ConnectError};
 
 #[tokio::main]
@@ -18,9 +26,99 @@ async fn main() {
         .await
         .expect("failed to get info");
 
-    // We only print it here, note that in real-life code you may want to call `.into_inner()` on
-    // the response to get the message.
-    println!("{info:#?}");
+    let pubkey = PublicKey::from_str(&info.into_inner().identity_pubkey).unwrap();
+    println!("Starting lndk for node: {pubkey}");
+
+    let _node_signer = LndNodeSigner::new(pubkey, client.signer());
+}
+
+struct LndNodeSigner<'a> {
+    pubkey: PublicKey,
+    secp_ctx: Secp256k1<secp256k1::All>,
+    signer: RefCell<&'a mut tonic_lnd::SignerClient>,
+}
+
+impl<'a> LndNodeSigner<'a> {
+    fn new(pubkey: PublicKey, signer: &'a mut tonic_lnd::SignerClient) -> Self {
+        LndNodeSigner {
+            pubkey,
+            secp_ctx: Secp256k1::new(),
+            signer: RefCell::new(signer),
+        }
+    }
+}
+
+impl<'a> NodeSigner for LndNodeSigner<'a> {
+    /// Get node id based on the provided [`Recipient`].
+    ///
+    /// This method must return the same value each time it is called with a given [`Recipient`]
+    /// parameter.
+    ///
+    /// Errors if the [`Recipient`] variant is not supported by the implementation.
+    fn get_node_id(&self, recipient: Recipient) -> Result<PublicKey, ()> {
+        match recipient {
+            Recipient::Node => Ok(self.pubkey),
+            Recipient::PhantomNode => Err(()),
+        }
+    }
+
+    /// Gets the ECDH shared secret of our node secret and `other_key`, multiplying by `tweak` if
+    /// one is provided. Note that this tweak can be applied to `other_key` instead of our node
+    /// secret, though this is less efficient.
+    ///
+    /// Errors if the [`Recipient`] variant is not supported by the implementation.
+    fn ecdh(
+        &self,
+        recipient: Recipient,
+        other_key: &PublicKey,
+        tweak: Option<&Scalar>,
+    ) -> Result<SharedSecret, ()> {
+        match recipient {
+            Recipient::Node => {}
+            Recipient::PhantomNode => return Err(()),
+        }
+
+        // Clone other_key so that we can tweak it (if a tweak is required). We choose to tweak the
+        // `other_key` because LND's API accept a tweak parameter (so we can't tweak our secret).
+        let tweaked_key = if let Some(tweak) = tweak {
+            other_key.mul_tweak(&self.secp_ctx, tweak).map_err(|_| ())?
+        } else {
+            *other_key
+        };
+
+        let shared_secret = match block_on(self.signer.borrow_mut().derive_shared_key(
+            tonic_lnd::signrpc::SharedKeyRequest {
+                ephemeral_pubkey: tweaked_key.serialize().into_iter().collect::<Vec<u8>>(),
+                key_desc: None,
+                ..Default::default()
+            },
+        )) {
+            Ok(shared_key_resp) => shared_key_resp.into_inner().shared_key,
+            Err(_) => return Err(()),
+        };
+
+        match SharedSecret::from_slice(&shared_secret) {
+            Ok(secret) => Ok(secret),
+            Err(_) => Err(()),
+        }
+    }
+
+    fn get_inbound_payment_key_material(&self) -> KeyMaterial {
+        unimplemented!("not required for onion messaging");
+    }
+
+    fn sign_invoice(
+        &self,
+        _hrp_bytes: &[u8],
+        _invoice_data: &[u5],
+        _recipient: Recipient,
+    ) -> Result<RecoverableSignature, ()> {
+        unimplemented!("not required for onion messaging");
+    }
+
+    fn sign_gossip_message(&self, _msg: UnsignedGossipMessage) -> Result<Signature, ()> {
+        unimplemented!("not required for onion messaging");
+    }
 }
 
 fn get_lnd_client(cfg: LndCfg) -> Result<Client, ConnectError> {


### PR DESCRIPTION
This PR implements the portions of the `NodeSigner` trait that are required for onion messages. Methods that are not required are just left as `unimplemented` because we do not expect the onion messages code to call them.

Fixes #4. 