### PR TITLE
initial github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: ['master']
+  pull_request:
+    branches: ['*']
+
+jobs:
+  build_and_test:
+    name: LNDK Rust Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-targets --benches --frozen
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- --deny warnings


### PR DESCRIPTION
Uses the cargo action to:
- build a release artifact
- run all tests and benches
  - requires Cargo.lock and cache file up to date
- run rustfmt in 'check' mode to verify formatting is standard
- run clippy, and fail on warnings