### PR TITLE
actions: include token in codecov action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,3 +54,4 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov sometimes runs into rate limiting issues from github, including the token directly should help. 

As in: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954
