### PR TITLE
Silence clippy warnings from configureme dependency

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod internal {
     #![allow(clippy::unnecessary_lazy_evaluations)]
     #![allow(clippy::useless_conversion)]
     #![allow(clippy::never_loop)]
+    #![allow(clippy::uninlined_format_args)]
 
     include!(concat!(env!("OUT_DIR"), "/configure_me_config.rs"));
 }


### PR DESCRIPTION
Some noisey clippy warnings were introduced in #23, allow `uninlined_format_args` to silence warnings from dependency.

CI didn't trigger this because we allow warnings. 