### PR TITLE
Add crev note and security audit GH Action for PRs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,15 @@
+name: Security audit
+
+on:
+  pull_request:
+    paths: 
+      - '.github/workflows/audit.yml'
+      - '**/Cargo.*'
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ General guidelines for code contribution:
 2. Refactor commits should be done in their own commits, separately from logical changes.
 3. Wherever possible, new code should be covered by tests.
 4. Bug fixes should start with a test demonstrating the bug, then add the fix and update the test to illustrate that the bug has been addressed.
+5. It is recommended to always use [cargo-crev](https://github.com/crev-dev/cargo-crev) to verify the trustworthiness of any added dependencies, which should be kept to a minimum where possible.
 
 #### Process
 0. **Issue creation**: If no issue is open for the work you'd like to implement, please open one as a preliminary step so that other contributors can comment on the proposed approach and suitableness of the feature for the repo.

--- a/README.md
+++ b/README.md
@@ -58,3 +58,6 @@ Once we have an `OnionMessenger` that can process messages on behalf of the LND 
 3. [SendCustomMessage](https://lightning.engineering/api-docs/api/lnd/lightning/send-custom-message#grpc): poll the `OnionMessenger` for `next_onion_message_for_peer` and deliver queued outbound onion messages to LND for sending. 
 
 ![Onion message processing](docs/arch-onionmessageflow.png)
+
+NOTE: It is recommended to always use [cargo-crev](https://github.com/crev-dev/cargo-crev)
+to verify the trustworthiness of each of your dependencies, including this one.


### PR DESCRIPTION
Encourage the use of `cargo-crev` for auditing dependencies. Crev uses a web of trust of entities contributing reviews of crates within the Rust ecosystem in this case. Read more at https://github.com/crev-dev/cargo-crev and see similar use for `rust-bitcoin` at https://github.com/rust-bitcoin/rust-bitcoin/pull/1098.

This commit also adds a GitHub Action for PRs which runs `cargo-audit` to check dependencies for any known vulnerabilities along with their severity and steps to remedy. This should be less noisy than dependabot PRs but we can maybe consider that if we feel it's also helpful to keep track of dependency updates.

Work is part of #38.