### PR TITLE
README: Release cleanup part 1

### DIFF
--- a/ARCH.md
+++ b/ARCH.md
@@ -1,0 +1,22 @@
+## Architecture
+There are three components relevant to our architecture:
+
+1. [LDK](https://github.com/lightningdevkit/rust-lightning): imported as a dependency to provide onion message processing and forwarding capabilities.
+2. [LND](https://github.com/lightningnetwork/lnd): the grpc API that is exposed by the target LND node built with the appropriate rpc subservers.
+3. [LNDK](https://github.com/carlaKC/lndk): a thin rust shim that connects to LND's API (via grpc), acting as a shim that connects LND's APIs to LDK's functionality and providing input/output to the LND node.
+
+The use of LND's flexible API and LDK's modular lightning library allows us to re-use the bolt 12 implementation in LDK. LNDK itself is intended to act as a simple shim that facilitates communication between LND and the LDK library - wrapping API calls in trait implementations for LDK, converting types and passing messages between the LDK state machine and LND's APIs.
+
+So, basically, Frankeinstein's monster. With extra steps.
+
+### Onion Messages
+Onion messaging is implemented using by implementing a custom version of LDK's [OnionMessenger](https://github.com/lightningdevkit/rust-lightning/blob/435b3b480283e40f7b8a945eff6465438f39cd5b/lightning/src/onion_message/messenger.rs#L106) that can use LND's node key to process onion messages. This is achieved by implementing the [NodeSigner](https://github.com/lightningdevkit/rust-lightning/blob/fac5373687a4c7919c8639744dc712d922082cc3/lightning/src/chain/keysinterface.rs#L452) trait, making relevant calls to LND's `signerrpc` API to perform ECDH ops with the node's private key. All other components can use the built-in options available in LDK.
+
+![Onion messenger](docs/arch-onionmessenger.png)
+
+Once we have an `OnionMessenger` that can process messages on behalf of the LND node, we need to handle events that are relevant to the messenger.
+1. [SubscribePeerEvents](https://lightning.engineering/api-docs/api/lnd/lightning/subscribe-peer-events#grpc): subscribe to peer events and notify the `OnionMessenger` of `peer_connected` and `peer_disconnected` events.
+2. [SubscribeCustomMessages](https://lightning.engineering/api-docs/api/lnd/lightning/subscribe-custom-messages#grpc): receive incoming onion messages from LND and deliver them to the `OnionMessenger` via `handle_onion_message`
+3. [SendCustomMessage](https://lightning.engineering/api-docs/api/lnd/lightning/send-custom-message#grpc): poll the `OnionMessenger` for `next_onion_message_for_peer` and deliver queued outbound onion messages to LND for sending.
+
+![Onion message processing](docs/arch-onionmessageflow.png)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LNDK
 
 An experimental attempt at using [LDK](https://github.com/lightningdevkit/rust-lightning) to implement [bolt 12](https://github.com/lightning/bolts/pull/798) features for [LND](https://github.com/lightningnetwork/lnd). 
+* LNDK's [Architecture](https://github.com/carlaKC/lndk/blob/master/ARCH.md)
 * [Contributor guidelines](https://github.com/carlaKC/lndk/blob/master/CONTRIBUTING.md)
 * [Code of Conduct](https://github.com/carlaKC/lndk/blob/master/code_of_conduct.md)
 
@@ -66,29 +67,6 @@ In a more concrete example:
 * Run `cargo run -- --conf lndk.conf`
 
 - Use any of the commands with the --help option for more information about each argument.
-
-## Architecture
-There are three components relevant to our architecture:
-
-1. [LDK](https://github.com/lightningdevkit/rust-lightning): imported as a dependency to provide onion message processing and forwarding capabilities.
-2. [LND](https://github.com/lightningnetwork/lnd): the grpc API that is exposed by the target LND node built with the appropriate rpc subservers.
-3. [LNDK](https://github.com/carlaKC/lndk): a thin rust shim that connects to LND's API (via grpc), acting as a shim that connects LND's APIs to LDK's functionality and providing input/output to the LND node.
-
-The use of LND's flexible API and LDK's modular lightning library allows us to re-use the bolt 12 implementation in LDK. LNDK itself is intended to act as a simple shim that facilitates communication between LND and the LDK library - wrapping API calls in trait implementations for LDK, converting types and passing messages between the LDK state machine and LND's APIs.
-
-So, basically, Frankeinstein's monster. With extra steps.
-
-### Onion Messages
-Onion messaging is implemented using by implementing a custom version of LDK's [OnionMessenger](https://github.com/lightningdevkit/rust-lightning/blob/435b3b480283e40f7b8a945eff6465438f39cd5b/lightning/src/onion_message/messenger.rs#L106) that can use LND's node key to process onion messages. This is achieved by implementing the [NodeSigner](https://github.com/lightningdevkit/rust-lightning/blob/fac5373687a4c7919c8639744dc712d922082cc3/lightning/src/chain/keysinterface.rs#L452) trait, making relevant calls to LND's `signerrpc` API to perform ECDH ops with the node's private key. All other components can use the built-in options available in LDK.
-
-![Onion messenger](docs/arch-onionmessenger.png)
-
-Once we have an `OnionMessenger` that can process messages on behalf of the LND node, we need to handle events that are relevant to the messenger. 
-1. [SubscribePeerEvents](https://lightning.engineering/api-docs/api/lnd/lightning/subscribe-peer-events#grpc): subscribe to peer events and notify the `OnionMessenger` of `peer_connected` and `peer_disconnected` events.
-2. [SubscribeCustomMessages](https://lightning.engineering/api-docs/api/lnd/lightning/subscribe-custom-messages#grpc): receive incoming onion messages from LND and deliver them to the `OnionMessenger` via `handle_onion_message`
-3. [SendCustomMessage](https://lightning.engineering/api-docs/api/lnd/lightning/send-custom-message#grpc): poll the `OnionMessenger` for `next_onion_message_for_peer` and deliver queued outbound onion messages to LND for sending. 
-
-![Onion message processing](docs/arch-onionmessageflow.png)
 
 NOTE: It is recommended to always use [cargo-crev](https://github.com/crev-dev/cargo-crev)
 to verify the trustworthiness of each of your dependencies, including this one.

--- a/README.md
+++ b/README.md
@@ -6,15 +6,46 @@ An experimental attempt at using [LDK](https://github.com/lightningdevkit/rust-l
 
 ## Setting up LNDK
 
-To run `LNDK`, `LND` is assumed to be running. For directions on how to do this, try [this guide](https://docs.lightning.engineering/lightning-network-tools/lnd/run-lnd).
+#### Compiling LND
 
-When compiling `LND`, make sure that the peersrpc and signerrpc services are enabled, like this:
+To run `LNDK`, `LND` is assumed to be running. You'll need to make some adjustments when compiling and running `LND` to make it compatible with `LNDK`.
+
+First, you'll need to run a particular [branch](https://github.com/lightningnetwork/lnd/tree/v0.16.2-patch-customfeatures) of `LND` to allow the advertising of onion_message feature bits. To do so, follow these steps:
+
+```
+git clone https://github.com/lightningnetwork/lnd
+cd lnd
+git checkout v0.16.2-patch-customfeatures
+```
+
+While on this branch, compile `LND`. Make sure that the peersrpc and signerrpc services and dev tag are enabled, like this:
 
 `make install --tags="peersrpc signerrpc dev"`
 
-`LND` must also be run with `--protocol.custom-message=513` to allow it to report onion messages to `LNDK`, which requires LND version [v0.16.0-beta)](https://github.com/lightningnetwork/lnd/releases/tag/v0.16.0-beta).
+Note that this guide assumes some familiarity with setting up `LND`. If you're looking to get up to speed, try [this guide](https://docs.lightning.engineering/lightning-network-tools/lnd/run-lnd).
 
-In order to successfully connect to `LND`, we need to pass in the grpc address and authentication credentials. These values can be passed in via the command line when running the `LNDK` program, like this:
+#### Running LND
+
+Once you're ready to run `LND`, the binary must be run with `--protocol.custom-message=513` to allow it to report onion messages to `LNDK` as well as `--protocol.custom-nodeann=39` `--protocol.custom-init=39` for advertising the onion message feature bits.
+
+There are two ways you can do this:
+
+1) Pass these options directly to `LND` when running it:
+
+`lnd --protocol.custom-message=513 --protocol.custom-nodeann=39 --protocol.custom-init=39`
+
+2) Adding these to the config file `lnd.conf`:
+
+```
+[protocol]
+protocol.custom-message=513
+protocol.custom-nodeann=39
+protocol.custom-init=39
+```
+
+#### Running LNDK
+
+In order for `LNDK` successfully connect to `LND`, we need to pass in the grpc address and authentication credentials. These values can be passed in via the command line when running the `LNDK` program, like this:
 
 - `cargo run -- --address=<ADDRESS> --cert=<TLSPATH> --macaroon=<MACAROONPATH>`
 

--- a/README.md
+++ b/README.md
@@ -68,5 +68,7 @@ In a more concrete example:
 
 - Use any of the commands with the --help option for more information about each argument.
 
+## Security
+
 NOTE: It is recommended to always use [cargo-crev](https://github.com/crev-dev/cargo-crev)
 to verify the trustworthiness of each of your dependencies, including this one.


### PR DESCRIPTION
This PR aims to satisfy the first and second release cleanup tasks described in #44:
- Adds instructions for building the specific branch of LND requires, as well as setting the needed protocol flags
- Clarifies some setup instructions by splitting "setting up LNDK" section into a few subsections
- Moves the architecture section of the README into a new file
- Splits the cargo-crev note into a new section of the README